### PR TITLE
Obtain keys from external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Keys
+keys.xml

--- a/app/src/main/java/com/github/cfogrady/vbnfc/MainActivity.kt
+++ b/app/src/main/java/com/github/cfogrady/vbnfc/MainActivity.kt
@@ -43,7 +43,12 @@ class MainActivity : ComponentActivity() {
     private var secrets: VBNfcHandler.Secrets
 
     init {
-        secrets = VBNfcHandler.Secrets("", "", "", intArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)) // Not Real Keys or cypher.
+        secrets = VBNfcHandler.Secrets(
+            passwordKey1 = getString(R.string.password_key_1),
+            passwordKey2 = getString(R.string.password_key_2),
+            decryptionKey = getString(R.string.decryption_key),
+            substitutionCypher = resources.getIntArray(R.array.substitution_cypher)
+        )
         vbNfcHandlerFactory = VBNfcHandlerFactory(secrets, secrets, secrets)
     }
 

--- a/app/src/main/java/com/github/cfogrady/vbnfc/MainActivity.kt
+++ b/app/src/main/java/com/github/cfogrady/vbnfc/MainActivity.kt
@@ -39,18 +39,8 @@ import kotlinx.coroutines.coroutineScope
 class MainActivity : ComponentActivity() {
 
     private lateinit var nfcAdapter: NfcAdapter
-    private var vbNfcHandlerFactory: VBNfcHandlerFactory
-    private var secrets: VBNfcHandler.Secrets
-
-    init {
-        secrets = VBNfcHandler.Secrets(
-            passwordKey1 = getString(R.string.password_key_1),
-            passwordKey2 = getString(R.string.password_key_2),
-            decryptionKey = getString(R.string.decryption_key),
-            substitutionCypher = resources.getIntArray(R.array.substitution_cypher)
-        )
-        vbNfcHandlerFactory = VBNfcHandlerFactory(secrets, secrets, secrets)
-    }
+    private lateinit var secrets: VBNfcHandler.Secrets
+    private lateinit var vbNfcHandlerFactory: VBNfcHandlerFactory
 
     @OptIn(ExperimentalStdlibApi::class)
     override fun onNewIntent(intent: Intent?) {
@@ -69,6 +59,14 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        secrets = VBNfcHandler.Secrets(
+            passwordKey1 = resources.getString(R.string.password1),
+            passwordKey2 = resources.getString(R.string.password2),
+            decryptionKey = resources.getString(R.string.decryptionKey),
+            substitutionCypher = resources.getIntArray(R.array.substitutionArray)
+        )
+        vbNfcHandlerFactory = VBNfcHandlerFactory(secrets, secrets, secrets)
+
         val maybeNfcAdapter = NfcAdapter.getDefaultAdapter(this)
         if (maybeNfcAdapter == null) {
             Toast.makeText(this, "No NFC on device!", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
For some reason Android Studio wants the keys file under the library's `res` folder, so, in order to make use of this key file you need to create a keys.xml file inside `lib-vb-nfc/res/values/keys.xml` with the following:

```xml
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <string name="password1"></string>
    <string name="password2"></string>
    <string name="decryptionKey"></string>
    <integer-array name="substitutionArray">0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15</integer-array>
</resources>
```

Also initialization of the secrets was changed to lateinit because application would crash trying to load resources before the MainActivity loads.